### PR TITLE
Rename project from 'gestiondevol_test' to 'gestiondevol' in package.…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "gestiondevol_test",
+  "name": "gestiondevol",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gestiondevol_test",
+      "name": "gestiondevol",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gestiondevol_test",
+  "name": "gestiondevol",
   "version": "1.0.0",
   "description": "Système de réservation de billets d'avion avec gestion de profil utilisateur.",
   "main": "server.js",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the project name from "gestiondevol_test" to "gestiondevol" to reflect the final project name.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Updated the project name to "gestiondevol" from "gestiondevol_test".…json and package-lock.json